### PR TITLE
Add retract case for Go 1.16 go.mod files

### DIFF
--- a/extractor/src/extractors/GoModExtractor.ts
+++ b/extractor/src/extractors/GoModExtractor.ts
@@ -97,7 +97,7 @@ export default class GoModExtractor implements Extractor {
                     break;
                 
                 default:
-                    throw new Error(`parse error: unsupported directive: ${directive}`);
+                    console.debug(`parse error: unsupported directive: ${directive}`);
             }
         }
 

--- a/extractor/src/extractors/GoModExtractor.ts
+++ b/extractor/src/extractors/GoModExtractor.ts
@@ -1,9 +1,12 @@
 import {Dependency, DependencyManagementFile} from "@depscloud/api/v1alpha/deps";
+import {getLogger} from "log4js";
 import Extractor from "./Extractor";
 import ExtractorFile from "./ExtractorFile";
 import parseImportPath from "./goutils/parseImportPath";
 import Languages from "./Languages";
 import MatchConfig from "../matcher/MatchConfig";
+
+const logger = getLogger();
 
 export default class GoModExtractor implements Extractor {
     public matchConfig(): MatchConfig {
@@ -97,7 +100,7 @@ export default class GoModExtractor implements Extractor {
                     break;
                 
                 default:
-                    console.debug(`parse error: unsupported directive: ${directive}`);
+                    logger.debug(`parse error: unsupported directive: ${directive}`);
             }
         }
 

--- a/extractor/src/extractors/GoModExtractor.ts
+++ b/extractor/src/extractors/GoModExtractor.ts
@@ -84,7 +84,8 @@ export default class GoModExtractor implements Extractor {
                         }
                     }
                     break;
-
+                
+                case "retract":
                 case "exclude":
                     i++;    // exclude on subsequent lines
                     for (; i < lines.length && lines[i] !== ")"; i++) {

--- a/extractor/src/extractors/GoModExtractor.ts
+++ b/extractor/src/extractors/GoModExtractor.ts
@@ -92,7 +92,10 @@ export default class GoModExtractor implements Extractor {
                         // intentionally empty
                     }
                     break;
-
+                
+                case "//":
+                    break;
+                
                 default:
                     throw new Error(`parse error: unsupported directive: ${directive}`);
             }

--- a/extractor/src/extractors/testdata/go.mod
+++ b/extractor/src/extractors/testdata/go.mod
@@ -27,6 +27,10 @@ retract (
 	// ending in a parentheses
 )
 
+// This is a comment that will read as a directive, skip and log it
+
+skipme // Unknown directive, skip and log it
+
 require (
 	github.com/gogo/protobuf v1.2.1
 	github.com/depscloud/rds v0.0.2

--- a/extractor/src/extractors/testdata/go.mod
+++ b/extractor/src/extractors/testdata/go.mod
@@ -12,6 +12,21 @@ replace (
 	google.golang.org/grpc v1.18.0 => google.golang.org/grpc v1.18.0
 )
 
+exclude google.golang.org/grpc v1.18.0
+
+exclude (
+	github.com/sirupsen/logrus v1.3.0
+	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd
+)
+
+retract // place holder for future version of Go
+
+retract ( 
+	// Multiple lines
+	// of package versions
+	// ending in a parentheses
+)
+
 require (
 	github.com/gogo/protobuf v1.2.1
 	github.com/depscloud/rds v0.0.2


### PR DESCRIPTION
Addresses #69 

This case should behave exactly like the `exclude` case.

Should probably revisit once [Go 1.16 release notes](https://tip.golang.org/doc/go1.16#go-command) include more information.