### PR TITLE
ci: Upgrade actions-setup-minikube to v2.0.1

### DIFF
--- a/.github/workflows/deps-integration.yaml
+++ b/.github/workflows/deps-integration.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.0.0
+        uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: 'v1.12.3'
           kubernetes version: 'v1.18.2'

--- a/.github/workflows/extractor-integration.yaml
+++ b/.github/workflows/extractor-integration.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.0.0
+        uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: 'v1.12.3'
           kubernetes version: 'v1.18.2'

--- a/.github/workflows/gateway-integration.yaml
+++ b/.github/workflows/gateway-integration.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.0.0
+        uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: 'v1.12.3'
           kubernetes version: 'v1.18.2'

--- a/.github/workflows/indexer-integration.yaml
+++ b/.github/workflows/indexer-integration.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.0.0
+        uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: 'v1.12.3'
           kubernetes version: 'v1.18.2'

--- a/.github/workflows/tracker-integration.yaml
+++ b/.github/workflows/tracker-integration.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.0.0
+        uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: 'v1.12.3'
           kubernetes version: 'v1.18.2'


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` to the latest version.

Removes the following warnings caused by [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w):
```
Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Warning: The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Relates to:
- https://github.com/manusa/actions-setup-minikube/issues/22
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/